### PR TITLE
kaggle claim_key verify function fix

### DIFF
--- a/notary-server/src/airdrop.rs
+++ b/notary-server/src/airdrop.rs
@@ -323,7 +323,7 @@ pub async fn generate_signature_userid(
     attr_transcript: RedactedTranscript,
     server_name: String,
     merkle_root: &MerkleRoot,
-) -> Result<(String, Vec<u8>), Error> {
+) -> Result<(String, Vec<u8>, String), Error> {
     // Convert the received transcript to a UTF-8 string
     let auth_rcv = String::from_utf8(recv_transcript.data().to_vec())
         .unwrap_or("Could not convert sent data to string".to_string());
@@ -334,7 +334,7 @@ pub async fn generate_signature_userid(
     // Parse the user ID from the received transcripts
     let user_id = parse_value(auth_rcv, "id\":".to_string(), ",".to_string());
 
-    let user_id_2 = parse_value(attr_rcv, "id\":".to_string(), ",".to_string());
+    let user_id_2 = parse_value(attr_rcv, "userId\":".to_string(), ",".to_string());
 
     println!("user_id = {:} user_id_2 = {:}", user_id, user_id_2);
 
@@ -382,11 +382,11 @@ pub async fn generate_signature_userid(
         let signature: Ed25519Signature = signer.sign(combined_bytes);
         info!("signature {}", signature.to_string());
 
-        return Ok((signature.to_string(), nullifier_vec));
+        return Ok((signature.to_string(), nullifier_vec, claim_key));
     } else {
         // If the user already has a claim key, return an empty string and an empty vector
         println!("🟠 User_id already inserted");
-        return Ok(("".to_string(), Vec::new()));
+        return Ok(("".to_string(), Vec::new(), claim_key));
     }
 }
 

--- a/notary-server/src/service.rs
+++ b/notary-server/src/service.rs
@@ -203,7 +203,7 @@ pub async fn verify_proof(
     };
 
     //info!("payload: {:#?}", payload);
-    let (signature, nullifier) = verify(payload).await.unwrap();
+    let (signature, nullifier, claim_key) = verify(payload).await.unwrap();
 
     // Return a JSON with field success = "OK" in the response to the client
     (
@@ -212,6 +212,7 @@ pub async fn verify_proof(
             "success": "OK",
             "signature": signature.to_string(),
             "nullifier": nullifier,
+            "claim_key": claim_key,
         })),
     )
         .into_response()
@@ -288,7 +289,7 @@ pub fn parse_proofs(
 /// or an error if the verification fails.
 ///
 
-pub async fn verify(request: VerifyProofRequest) -> Result<(String, Vec<u8>), NotaryServerError> {
+pub async fn verify(request: VerifyProofRequest) -> Result<(String, Vec<u8>, String), NotaryServerError> {
     let (
         (auth_header, auth_server_name, auth_substrings),
         (attr_header, attr_server_name, attr_substrings),
@@ -362,7 +363,7 @@ pub async fn verify(request: VerifyProofRequest) -> Result<(String, Vec<u8>), No
         )
         .await;
         return match res {
-            Ok((signature, nullifier)) => Ok((signature, nullifier)),
+            Ok((signature, nullifier, claim_key)) => Ok((signature, nullifier, claim_key)),
             Err(e) => Err(NotaryServerError::BadProverRequest(e.to_string())),
         };
     } else {


### PR DESCRIPTION
sending claim_key in verify response, changed parsed_value start_key to userId in attributeProof parsing